### PR TITLE
refactor: Remove i3wm directory in setup script

### DIFF
--- a/scripts/setup-i3wm.sh
+++ b/scripts/setup-i3wm.sh
@@ -10,4 +10,6 @@ cd $builddir/i3wm
 ./setup.sh
 cd $builddir
 
+rm $builddir/i3wm -rf
+
 exit 0


### PR DESCRIPTION
Remove i3wm directory in setup-i3wm.sh for better cleanup and organization.